### PR TITLE
Adds new Meetup.com link to the nav

### DIFF
--- a/lib/cbus_elixir_web/templates/shared/_header.html.eex
+++ b/lib/cbus_elixir_web/templates/shared/_header.html.eex
@@ -16,6 +16,6 @@
         <a href="https://github.com/columbus-elixir" target="_blank">Github</a>
     </div>
     <div class="column">
-        <a href="https://twitter.com/columbuselixir" target="_blank">Linkedin</a>
+        <a href="https://www.meetup.com/meetup-group-dXjIQyMO/events/zkfzjpyxfbjb/" target="_blank">Meetup</a>
     </div>
 </div>


### PR DESCRIPTION
![columbus elixir 2018-02-20 12-23-13](https://user-images.githubusercontent.com/2805/36438756-d5bc4392-1638-11e8-8af1-eb185ac8fb9f.png)

I nixed the LinkedIn nav item in favor of Meetup.