### PR TITLE
Add FontAwesome and simple nav images

### DIFF
--- a/lib/cbus_elixir_web/templates/layout/app.html.eex
+++ b/lib/cbus_elixir_web/templates/layout/app.html.eex
@@ -21,6 +21,7 @@
         <%= render CbusElixirWeb.SharedView, "_footer.html", assigns %>
       </div>
     </main>
+    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>

--- a/lib/cbus_elixir_web/templates/shared/_header.html.eex
+++ b/lib/cbus_elixir_web/templates/shared/_header.html.eex
@@ -10,12 +10,15 @@
 </div>
 <div class="row nav">
     <div class="column">
+        <i class="fab fa-twitter"></i>
         <a href="https://twitter.com/columbuselixir" target="_blank">Twitter</a>
     </div>
     <div class="column">
+        <i class="fab fa-github"></i>
         <a href="https://github.com/columbus-elixir" target="_blank">Github</a>
     </div>
     <div class="column">
+        <i class="fab fa-linkedin-in"></i>
         <a href="https://twitter.com/columbuselixir" target="_blank">Linkedin</a>
     </div>
 </div>


### PR DESCRIPTION
![columbus elixir 2018-02-20 13-15-15](https://user-images.githubusercontent.com/2805/36441268-1b49d7f6-1640-11e8-96aa-2a20ac89f6b1.png)

These can be moved/changed/added of course. We're using the free version.
Here is a list of icons: https://fontawesome.com/icons?d=gallery&m=free