### PR TITLE
Robb/Broken-Query-Test

### DIFF
--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -14,7 +14,7 @@
         <h2 class="title myriad">This Month's Speakers</h2>
         <%= if Enum.empty?(@next_meeting.speakers) do %>
             <p>Our next speakers TBA</p>
-        <%= else %>
+        <% else %>
             <ul class="list">
                 <%= Enum.map(@next_meeting.speakers, fn(s) -> %>
                     <li>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,11 +13,11 @@
 alias CbusElixir.Repo
 alias CbusElixir.App.Meeting
 
-start = Timex.beginning_of_month(Timex.now)
+start_date = Timex.beginning_of_month(~N[2018-03-06T00:00:00])
 
 
 Enum.each(0..100, fn(x) ->
-  date = Timex.shift(start, months: x)
+  date = Timex.shift(start_date, months: x)
   days = Enum.find(0..6, fn d -> Timex.shift(date, days: d) |> Date.day_of_week() == 2 end)
   meeting_date = Timex.shift(date, days: days)
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 alias CbusElixir.Repo
 alias CbusElixir.App.Meeting
 
-start_date = Timex.beginning_of_month(~N[2018-03-06T00:00:00])
+start_date = ~N[2018-03-01T00:00:00]
 
 
 Enum.each(0..100, fn(x) ->


### PR DESCRIPTION
This fixes "Date Query String" in [page_controller_test](https://github.com/ieatkimchi/marketing/blob/master/test/cbus_elixir_web/controllers/page_controller_test.exs)

Creates seed meetings from the first cbus_elixir meet date.
Old code created meetings only from date seed file was originally run. If you seeded the db after march '18 the "Date Query String" test will fail due to static date. 

Test db needs to be dropped once otherwise the incrementing meeting_id will break [speaker tests](https://github.com/ieatkimchi/marketing/blob/master/test/cbus_elixir_web/controllers/speaker_controller_test.exs) in 
 the speaker fixture relies on @create_attrs which has a static meeting_id. (42 and 43)
