### PR TITLE
Sorted speakers desc by meeting id on speakers page

### DIFF
--- a/lib/cbus_elixir/app/app.ex
+++ b/lib/cbus_elixir/app/app.ex
@@ -7,6 +7,7 @@ defmodule CbusElixir.App do
   alias CbusElixir.Repo
 
   alias CbusElixir.App.Speaker
+  alias CbusElixir.App.Meeting
   alias CbusElixir.App.Attendee
 
   @doc """
@@ -19,9 +20,12 @@ defmodule CbusElixir.App do
 
   """
   def list_speakers do
-    Speaker 
-    |> order_by(desc: :meeting_id) 
+    query = from s in Speaker,
+            join: m in assoc(s, :meeting),
+            order_by: [desc: m.date]
+    speakers = query
     |> Repo.all
+    |> Repo.preload([:meeting])   
   end
 
   @doc """

--- a/lib/cbus_elixir/app/app.ex
+++ b/lib/cbus_elixir/app/app.ex
@@ -19,7 +19,7 @@ defmodule CbusElixir.App do
 
   """
   def list_speakers do
-    Repo.all(Speaker)
+    Speaker |> order_by(desc: :meeting_id) |> Repo.all
   end
 
   @doc """

--- a/lib/cbus_elixir/app/app.ex
+++ b/lib/cbus_elixir/app/app.ex
@@ -19,7 +19,9 @@ defmodule CbusElixir.App do
 
   """
   def list_speakers do
-    Speaker |> order_by(desc: :meeting_id) |> Repo.all
+    Speaker 
+    |> order_by(desc: :meeting_id) 
+    |> Repo.all
   end
 
   @doc """

--- a/lib/cbus_elixir_web/templates/speaker/index.html.eex
+++ b/lib/cbus_elixir_web/templates/speaker/index.html.eex
@@ -21,7 +21,7 @@
       <td><%= speaker.url %></td>
       <td><%= speaker.title %></td>
       <td><%= speaker.email %></td>
-      <td><%= speaker.meeting_id %></td>
+      <td><%= formatted_date(speaker.meeting.date) %></td>
 
       <td class="text-right">
         <span><%= link "Show", to: speaker_path(@conn, :show, speaker), class: "btn btn-default btn-xs" %></span>


### PR DESCRIPTION
Added in to have the returned list of speakers sorted by the meeting id in descending order so the most recent speakers are at the top. Up to now the oldest have been at the top and it has always been that you have had to scroll all the way to the bottom if you needed to look at recent speakers. This sort will correct that. 

![image](https://user-images.githubusercontent.com/5077100/50099831-fe305200-01ec-11e9-8e49-1d4d37dc3bd3.png)
