### PR TITLE
Allow to show speakers list

### DIFF
--- a/lib/cbus_elixir_web/controllers/speaker_controller.ex
+++ b/lib/cbus_elixir_web/controllers/speaker_controller.ex
@@ -3,7 +3,7 @@ defmodule CbusElixirWeb.SpeakerController do
 
   alias CbusElixir.App
   alias CbusElixir.App.Speaker
-  plug(BasicAuth, use_config: {:cbus_elixir, :cbus_auth_config})
+  plug(BasicAuth, [use_config: {:cbus_elixir, :cbus_auth_config}] when action in [:new, :edit, :delete])
 
   def index(conn, _params) do
     speakers = App.list_speakers()


### PR DESCRIPTION
Updated basic auth config to allow viewing of `/speakers` endpoint, but required password on `edit`, `new`, `delete` endpoints so that users cannot edit those things.