### PR TITLE
Updated to now with tz declared

### DIFF
--- a/lib/cbus_elixir_web/controllers/page_controller.ex
+++ b/lib/cbus_elixir_web/controllers/page_controller.ex
@@ -7,7 +7,7 @@ defmodule CbusElixirWeb.PageController do
   def index(conn, params) do
     next_meeting =
       params["date"]
-      |> DateParser.parse_meeting_date(Timex.today())
+      |> DateParser.parse_meeting_date(Timex.now("America/New_York"))
       |> Meetings.next_meeting()
 
     render(conn, "index.html", next_meeting: next_meeting)

--- a/lib/cbus_elixir_web/plugs/set_next_meeting.ex
+++ b/lib/cbus_elixir_web/plugs/set_next_meeting.ex
@@ -10,7 +10,7 @@ defmodule CbusElixir.Plugs.SetNextMeeting do
     if conn.assigns[:next_meeting] do
       conn
     else
-      next_meeting = Meetings.next_meeting(Timex.today())
+      next_meeting = Meetings.next_meeting(Timex.now("America/New_York"))
       assign(conn, :next_meeting, next_meeting)
     end
   end


### PR DESCRIPTION
closes: #70 

Updated the timex call to be NOW with a declared TZ for eastern so that it is localized to Columbus. This should take care of the 5 hour offset which is causing the date of next meeting to flip at 7PM instead of midnight.