### PR TITLE
Add link to RSVP to meeting events

### DIFF
--- a/assets/css/_components.scss
+++ b/assets/css/_components.scss
@@ -1,3 +1,4 @@
+@import "components/buttons";
 @import "components/header";
 @import "components/image";
 @import "components/list";

--- a/assets/css/components/_buttons.scss
+++ b/assets/css/components/_buttons.scss
@@ -3,11 +3,12 @@
   text-transform: uppercase;
   text-decoration: none;
   background: $purple;
-  padding: 20px;
-  border-radius: 20px;
+  padding: 10px 20px;
+  border-radius: 15px;
   display: inline-block;
   border: none;
   transition: all 0.4s ease 0s;
+  margin-bottom: 15px;
 }
 
 .button_1:hover {

--- a/assets/css/components/_buttons.scss
+++ b/assets/css/components/_buttons.scss
@@ -1,0 +1,18 @@
+.button_1 {
+  color: #fff !important;
+  text-transform: uppercase;
+  text-decoration: none;
+  background: $purple;
+  padding: 20px;
+  border-radius: 20px;
+  display: inline-block;
+  border: none;
+  transition: all 0.4s ease 0s;
+}
+
+.button_1:hover {
+  text-shadow: 0px 0px 6px rgba(255, 255, 255, 1);
+  -webkit-box-shadow: 0px 5px 20px -10px rgba(0,0,0,0.57);
+  -moz-box-shadow: 0px 5px 20px -10px rgba(0,0,0,0.57);
+  transition: all 0.4s ease 0s;
+}

--- a/lib/cbus_elixir/app/meeting.ex
+++ b/lib/cbus_elixir/app/meeting.ex
@@ -9,6 +9,7 @@ defmodule CbusElixir.App.Meeting do
 
   schema "meetings" do
     field(:date, :utc_datetime)
+    field(:rsvp_link, :string)
     has_many(:speakers, Speaker)
     has_many(:attendees, Attendee)
 

--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -36,6 +36,7 @@
         <div class="next-meeting">
             <h2 class="title myriad">Next Meeting</h2>
             <p>
+                <a href="<%= @next_meeting.rsvp_link %>" target="_blank">RSVP</a><br />
                 <%= formatted_date(@next_meeting.date) %> at 6pm<br />
                 First Tuesday of Every Month
             </p>

--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -15,6 +15,7 @@
         <%= if Enum.empty?(@next_meeting.speakers) do %>
             <p>Our next speakers TBA</p>
         <% else %>
+            <a href="<%= @next_meeting.rsvp_link %>" target="_blank" class="button_1">RSVP for Event</a><br />
             <ul class="list">
                 <%= Enum.map(@next_meeting.speakers, fn(s) -> %>
                     <li>
@@ -36,7 +37,6 @@
         <div class="next-meeting">
             <h2 class="title myriad">Next Meeting</h2>
             <p>
-                <a href="<%= @next_meeting.rsvp_link %>" target="_blank">RSVP</a><br />
                 <%= formatted_date(@next_meeting.date) %> at 6pm<br />
                 First Tuesday of Every Month
             </p>

--- a/priv/repo/migrations/20191028151617_add_rsvp_link_to_meetings.exs
+++ b/priv/repo/migrations/20191028151617_add_rsvp_link_to_meetings.exs
@@ -1,0 +1,9 @@
+defmodule CbusElixir.Repo.Migrations.AddRsvpLinkToMeetings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:meetings) do
+      add :rsvp_link, :text
+    end
+  end
+end

--- a/priv/repo/migrations/20191028151617_add_rsvp_link_to_meetings.exs
+++ b/priv/repo/migrations/20191028151617_add_rsvp_link_to_meetings.exs
@@ -3,7 +3,7 @@ defmodule CbusElixir.Repo.Migrations.AddRsvpLinkToMeetings do
 
   def change do
     alter table(:meetings) do
-      add :rsvp_link, :text
+      add :rsvp_link, :string
     end
   end
 end


### PR DESCRIPTION
Closes: #87 

Added RSVP button to index page to show when we have speakers set. The button will open link in new tab. 

Added RSVP_Link to the meetings table. We will need to add the links via a query to start out. We will need to add admin way to add links to meetings moving forward in another ticket. 

![image](https://user-images.githubusercontent.com/5077100/67697783-7d4ef480-f97f-11e9-95bf-e11ed025331b.png)
