### PR TITLE
Format to fix CI failure

### DIFF
--- a/priv/repo/migrations/20191028220405_add_rsvp_link_to_meetings.exs
+++ b/priv/repo/migrations/20191028220405_add_rsvp_link_to_meetings.exs
@@ -3,7 +3,7 @@ defmodule CbusElixir.Repo.Migrations.AddRsvpLinkToMeetings do
 
   def change do
     alter table(:meetings) do
-      add :rsvp_link, :string
+      add(:rsvp_link, :string)
     end
   end
 end


### PR DESCRIPTION
I set up CI to fail on format. I'm not sure why it didn't run CI on https://github.com/columbus-elixir/marketing/pull/97 but this fixes it.

I think it may have to deal with you guys removing my access to the repo. Not sure why you did that exactly... 