### PR TITLE
Added IRC to index.html

### DIFF
--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -31,7 +31,14 @@
             </ul>
         <% end %>
         <h2 class="title myriad">Questions? Hop in to the IRC chat!</h2>
-        <iframe src="https://webchat.freenode.net?channels=#columbus-elixir" style="border:0;width:100%;height:450px;"></iframe>
+        <p>NB: Internet Relay Chat (IRC) is asynchronous and there will be times during which the organizers are not present in the chat. That said, we do check this channel almost daily so that communications don't become stale.</p>
+        <p>New to IRC? <a href="https://opensource.com/article/16/6/irc-quickstart-guide" target="_blank">Check out this quickstart guide!</a></p>
+        <p>The following accounts are registered with freenode's NickServ and are considered `official` representatives of the meetup:</p>
+        <ul>
+            <li>columbus-elixir</li>
+            <li>ce-max</li>
+        </ul>
+        <iframe src="https://webchat.freenode.net?channels=#columbus-elixir" style="border:0;width:100%;height:550px;"></iframe>
         <h2><a href="/meetings">Past Meetings</a></h2>
     </div>
 

--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -30,6 +30,8 @@
                 <% end) %>
             </ul>
         <% end %>
+        <h2 class="title myriad">Questions? Hop in to the IRC chat!</h2>
+        <iframe src="https://webchat.freenode.net?channels=#columbus-elixir" style="border:0;width:100%;height:450px;"></iframe>
         <h2><a href="/meetings">Past Meetings</a></h2>
     </div>
 

--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -31,7 +31,7 @@
             </ul>
         <% end %>
         <h2 class="title myriad">Questions? Hop in to the IRC chat!</h2>
-        <p>NB: Internet Relay Chat (IRC) is asynchronous and there will be times during which the organizers are not present in the chat. That said, we do check this channel almost daily so that communications don't become stale.</p>
+        <p>NB: Internet Relay Chat (IRC) is asynchronous and there will be times during which the organizers are not present in the chat. That said, we do <a href="https://freenode.logbot.info/columbus-elixir" target="_blank">check this channel</a> almost daily so that communications don't become stale.</p>
         <p>New to IRC? <a href="https://opensource.com/article/16/6/irc-quickstart-guide" target="_blank">Check out this quickstart guide!</a></p>
         <p>The following accounts are registered with freenode's NickServ and are considered `official` representatives of the meetup:</p>
         <ul>

--- a/lib/cbus_elixir_web/templates/page/index.html.eex
+++ b/lib/cbus_elixir_web/templates/page/index.html.eex
@@ -10,7 +10,6 @@
             <li>Providing an excellent place for anyone (novice or expert) to start learning about Elixir</li>
         </ul>
 
-
         <h2 class="title myriad">This Month's Speakers</h2>
         <%= if Enum.empty?(@next_meeting.speakers) do %>
             <p>Our next speakers TBA</p>
@@ -30,15 +29,6 @@
                 <% end) %>
             </ul>
         <% end %>
-        <h2 class="title myriad">Questions? Hop in to the IRC chat!</h2>
-        <p>NB: Internet Relay Chat (IRC) is asynchronous and there will be times during which the organizers are not present in the chat. That said, we do <a href="https://freenode.logbot.info/columbus-elixir" target="_blank">check this channel</a> almost daily so that communications don't become stale.</p>
-        <p>New to IRC? <a href="https://opensource.com/article/16/6/irc-quickstart-guide" target="_blank">Check out this quickstart guide!</a></p>
-        <p>The following accounts are registered with freenode's NickServ and are considered `official` representatives of the meetup:</p>
-        <ul>
-            <li>columbus-elixir</li>
-            <li>ce-max</li>
-        </ul>
-        <iframe src="https://webchat.freenode.net?channels=#columbus-elixir" style="border:0;width:100%;height:550px;"></iframe>
         <h2><a href="/meetings">Past Meetings</a></h2>
     </div>
 
@@ -69,5 +59,54 @@
                 </a>
             </div>
         </div>
+    </div>
+</div>
+                        
+<!-- IRC Info -->
+<div class="row main-content">
+    <div class="row content">
+        <div class="column">
+            <h2 class="title myriad">Quick Question? Hop into the IRC chat!</h2>
+            <ul>
+                <li>NB: Internet Relay Chat (IRC) is asynchronous and there will be times during which the organizers are not present in the chat. That said, we do <a href="https://freenode.logbot.info/columbus-elixir" target="_blank">check the logs</a> for this channel, #columbus-elixir, almost daily so that communications don't become stale.</li>
+            <li>New to IRC? <a href="https://opensource.com/article/16/6/irc-quickstart-guide" target="_blank">Check out this quickstart guide!</a></li>
+            <li>The following accounts are registered with freenode's NickServ and are considered `official` representatives of the meetup:</li>
+            </ul>
+        </div>
+    </div>
+</div>
+                        
+<!-- IRC -->        
+<div class="row main-content">
+    <div class="column column-33 sidebar">
+        <table>
+            <tr>
+                <th>Organizer</th>
+                <th>IRC Nick[name]/Handle</th>
+            </tr>
+            <tr>
+                <td>Crosby</td>
+                <td>ce-crosby</td>
+            </tr>
+            <tr>
+                <td>Izzy</td>
+                <td>ce-izzy</td>
+            </tr>
+            <tr>
+                <td>Parker</td>
+                <td>ce-parker</td>
+            </tr>
+            <tr>
+                <td>Jess</td>
+                <td>ce-jess</td>
+            </tr>
+            <tr>
+                <td>Max</td>
+                <td>ce-max</td>
+            </tr>
+        </table>
+    </div>
+    <div class="column column-67">
+        <iframe src="https://kiwiirc.com/nextclient/irc.kiwiirc.com/?&theme=basic#columbus-elixir" style="border:0; width:100%; height:500px;"></iframe>
     </div>
 </div>


### PR DESCRIPTION
Adds a title and an iframe containing a kiwi IRC client pre-configured to launch a connection to webchat.freenode.net#columbus-elixir. Placement was arbitrary.

End users need only enter a nick-name and verify their humanity prior to joining.

Currently, the #columbus-elixir channel is set up with a secure password that I have access to. Likewise for the @columbus-elixir registered account on freenode.

### Sign in Screen
![image](https://user-images.githubusercontent.com/5077100/68134925-d0312a80-fef0-11e9-9e6a-48d3ca2e74d5.png)

### Chat Room Screen
![image](https://user-images.githubusercontent.com/5077100/68134945-da532900-fef0-11e9-9140-6500d15a283c.png)
